### PR TITLE
fix: 删除错误的样式覆盖

### DIFF
--- a/src/config/components/anchor-right/style.scss
+++ b/src/config/components/anchor-right/style.scss
@@ -3,14 +3,6 @@
         display: none;
     }
 
-    .sidebar-items{
-        .sidebar-item-children {
-            .sidebar-item-children {
-                display: block;
-            }
-        }
-    }
-
     .page {
         padding-right: 0;
     }
@@ -19,14 +11,6 @@
 @media (min-width: 1000px) {
     .anchor-right {
         display: block;
-    }
-
-    .sidebar-items{
-        .sidebar-item-children {
-            .sidebar-item-children {
-                display: none;
-            }
-        }
     }
 
     .page {


### PR DESCRIPTION
这两个样式造成了全局样式覆盖，影响了 children 菜单的显示

参考我的仓库：

```bash
 git clone https://github.com/Jsmond2016/study-everyday.git --depth=1
```

![image](https://github.com/dingshaohua-cn/vuepress-plugin-anchor-right/assets/25282180/d7c3ec64-07a7-4c38-856d-de8e6e9aae94)
![image](https://github.com/dingshaohua-cn/vuepress-plugin-anchor-right/assets/25282180/275a5f7f-ae0a-40a3-adab-9369673bc4b3)
![image](https://github.com/dingshaohua-cn/vuepress-plugin-anchor-right/assets/25282180/1555be82-8ba7-457b-839c-36fed96b7784)




